### PR TITLE
ci: publish multi-arch (linux/amd64 + linux/arm64) images

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -23,6 +23,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
+      - name: setup qemu
+        uses: docker/setup-qemu-action@v3
+
       - name: setup buildx
         uses: docker/setup-buildx-action@v3
 
@@ -42,6 +45,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             BUILD_WIDTH=${{ env.BUILD_WIDTH }}
             ZANO_REF=${{ matrix.zano-ref }}
@@ -57,6 +61,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             BUILD_WIDTH=${{ env.BUILD_WIDTH }}
             ZANO_REF=${{ matrix.zano-ref }}
@@ -72,6 +77,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             BUILD_WIDTH=${{ env.BUILD_WIDTH }}
             ZANO_REF=${{ matrix.zano-ref }}
@@ -98,6 +104,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
+      - name: setup qemu (testnet)
+        uses: docker/setup-qemu-action@v3
+
       - name: setup buildx (testnet)
         uses: docker/setup-buildx-action@v3
 
@@ -117,6 +126,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             BUILD_WIDTH=${{ env.BUILD_WIDTH }}
             ZANO_REF=${{ matrix.zano-ref }}
@@ -133,6 +143,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             BUILD_WIDTH=${{ env.BUILD_WIDTH }}
             ZANO_REF=${{ matrix.zano-ref }}
@@ -149,6 +160,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           build-args: |
             BUILD_WIDTH=${{ env.BUILD_WIDTH }}
             ZANO_REF=${{ matrix.zano-ref }}


### PR DESCRIPTION
## Summary

Extends `docker-build-and-push.yml` to publish multi-arch image manifests (`linux/amd64` + `linux/arm64`) for all three targets (`zano-runner`, `zanod-distroless`, `simplewallet-distroless`), on both the mainnet and the testnet job.

## Why

The `Dockerfile` builds Boost, OpenSSL and Zano from source — nothing in there is arch-specific, so it cross-builds on `linux/arm64` cleanly. ARM64 hosts (Apple Silicon, AWS Graviton, Raspberry Pi) currently fall back to amd64 emulation when pulling `canardleteer/zano:*` because no arm64 manifest is published.

## Change

- Add `docker/setup-qemu-action@v3` before `setup-buildx-action` in both jobs.
- Add `platforms: linux/amd64,linux/arm64` to every `docker/build-push-action@v6` call (3 mainnet + 3 testnet = 6 total).

The arm64 leg runs via QEMU on `ubuntu-latest`. If you'd rather use native arm64 runners (`ubuntu-24.04-arm`) via a build matrix that splits per platform and merges the manifest, happy to follow up.

## Out of scope

`docker-build.yml` (the PR-test workflow) is unchanged. It uses `load: true` + `docker run --rm ... --version` which is single-platform only — extending it to multi-arch would require a platform matrix (cross-product `zano-ref` × `platform`), which roughly doubles the test runtime. Easy to do as a separate PR if desired.

## Test plan

- [ ] Manual run produces images whose `docker manifest inspect canardleteer/zano:<tag>` lists both `amd64` and `arm64` entries
- [ ] Pull on an arm64 host (`docker pull --platform linux/arm64 canardleteer/zano:<tag>`) returns the native arm64 image